### PR TITLE
Push only specified tag

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -47,7 +47,7 @@ async function run() {
       else await lightweightTag(tagName)
 
       info('Pushing updated tag to repo...')
-      return await exec('git push --force --tags')
+      return await exec(`git push --force origin ${tagName}`)
     } else setFailed('Missing `GITHUB_TOKEN` environment variable')
   } catch (error) {
     setFailed(error instanceof Error ? error.message : error)


### PR DESCRIPTION
Running `git push --force --tags` will push all tags in local repo. If your repository have multiple tags, this may cause problem

Instead run specifically push for the tag that is being updated with `git push --force origin ${tagName}`