### PR TITLE
run action using Node.js v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     default: 'false'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'lib/index.js'
 
 branding:


### PR DESCRIPTION
GitHub plans to deprecate the v12 runtime and wants all actions to use v16 instead. See their announcement at
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/